### PR TITLE
[FIX] [ADD]#5 사이드바 리스트 디스패치 수정 / #7 메인페이지 스피너 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",
+    "react-spinners": "^0.11.0",
     "redux": "^4.1.0",
     "redux-actions": "^2.6.5",
     "redux-logger": "^3.0.6",

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -57,7 +57,9 @@ const Sidebar = (props) => {
               </Link>
             </li>
             <li className="menu-item">
-              <ProjectModal />
+              <div className="menu-link">
+                <ProjectModal sidebar={sidebar} />
+              </div>
             </li>
             <li className="menu-item">
               <Accordion defaultActiveKey="0" className="my-project-group">

--- a/src/components/Spinner.jsx
+++ b/src/components/Spinner.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { MoonLoader } from "react-spinners";
+const Spinner = (props) => {
+  if (!props.visible) {
+    // 연구 필요
+    return <></>;
+  }
+  return (
+    <SpinnerBG>
+      <SpinnerInner>
+        <MoonLoader color="#387E4B" size="100" />
+      </SpinnerInner>
+    </SpinnerBG>
+  );
+};
+Spinner.propTypes = {
+  visible: PropTypes.bool,
+};
+
+const SpinnerBG = styled.div`
+  position: fixed;
+  overflow-x: hidden;
+  overflow-y: auto;
+  outline: 0;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background-color: #fff;
+  z-index: 1000;
+`;
+const SpinnerInner = styled.div`
+  position: absolute;
+  left: 40%;
+  top: 40%;
+  transform: translate(-50%, -50%);
+`;
+export default Spinner;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ import Header from "./Header";
 import Sidebar from "./Sidebar";
 import Template from "./Template";
 import Contents from "./Contents";
+import Spinner from "./Spinner.jsx";
 
 /* Modal */
 import Modals from "./modals/Modals";
@@ -44,6 +45,7 @@ export {
   Sidebar,
   Template,
   Contents,
+  Spinner,
   /* == Modal */
   NoteModal,
   Modals,

--- a/src/components/modals/ProjectModal.jsx
+++ b/src/components/modals/ProjectModal.jsx
@@ -4,7 +4,7 @@ import ModalPortal from "../../util/ModalPotal";
 
 import { actionCreators as projectActions } from "../../modules/project";
 import { useDispatch } from "react-redux";
-
+import { history } from "../../modules/configStore";
 import { t } from "../../util/remConverter";
 import { ReactComponent as IconProjectAdd } from "../../styles/images/ico-project-add.svg";
 import modalSideImage from "../../styles/images/modalSideImage.PNG";
@@ -27,6 +27,8 @@ const ProjectModal = (props) => {
     };
     dispatch(projectActions.__postProject(project));
     setModalState(false);
+
+    history.push("./");
   };
 
   const changeProTitle = (e) => {
@@ -41,8 +43,15 @@ const ProjectModal = (props) => {
     <>
       {props.sidebar === "sidebar" ? (
         <>
-          <IconProjectAdd width="40" height="40" fill="#9A9A9A" className="menu-icon" onClick={() => setModalState(true)} />
-          <span className="menu-text" onClick={() => setModalState(true)}>
+          <IconProjectAdd
+            width="40"
+            height="40"
+            style={{ cursor: "pointer" }}
+            fill="#9A9A9A"
+            className="menu-icon"
+            onClick={() => setModalState(true)}
+          />
+          <span className="menu-text" style={{ cursor: "pointer" }} onClick={() => setModalState(true)}>
             프로젝트 만들기
           </span>
         </>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,22 +6,28 @@ import { t } from "../util/remConverter";
 import { Template, ProjectCardList, EmptyProject } from "../components";
 import { useSelector, useDispatch } from "react-redux";
 import { actionCreators as projectActions } from "../modules/project";
+import { Spinner } from "../components";
 
 // import { Container, Row, Col, Button, Alert, Breadcrumb, Card, Form } from 'react-bootstrap';
 
 const Home = ({ history }) => {
-  const project_list = useSelector(state => state.project.list);
+  const is_loading = useSelector((state) => state.project.is_loading);
+  const project_list = useSelector((state) => state.project.list);
+  const project_list_length = project_list.length;
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(projectActions.__setProject());
-  }, []);
+  }, [dispatch, project_list_length]);
 
   return (
-    <Template>
-      <main className="content" id="content">
-        {project_list.length > 0 ? <ProjectCardList /> : <EmptyProject />}
-      </main>
-    </Template>
+    <>
+      <Spinner visible={is_loading} />
+      <Template>
+        <main className="content" id="content">
+          {project_list.length > 0 ? <ProjectCardList /> : <EmptyProject />}
+        </main>
+      </Template>
+    </>
   );
 };
 


### PR DESCRIPTION

[FIX] #5 사이드바 리스트 디스패치 수정
프로젝트 생성, 수정, 삭제 시 사이드바 리스트 자동 랜더 불가 부분을 모듈에 직접 dispatch함으로써 수정
[ADD] #7 메인페이지 스피너 추가
메인 페이지 진입시, 프로젝트 없는 기본페이지 랜더되는 문제가 생겨 setproject 시 스피너를 추가함으로써 해결

